### PR TITLE
Add conversation practice pages

### DIFF
--- a/conversations/cab-driver.html
+++ b/conversations/cab-driver.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cab Driver Conversation</title>
+  <link rel="stylesheet" href="../styles.css">
+  <style>
+    .dialogue p {
+      margin: 10px 0;
+    }
+  </style>
+</head>
+<body>
+  <header class="hero" style="background-image: url('../background.png');">
+    <div class="overlay">
+      <h1>Cab Driver</h1>
+      <p>Practice chatting with a taxi driver.</p>
+      <a href="index.html" class="cta-button">Back to Conversations</a>
+    </div>
+  </header>
+
+  <section class="section">
+    <img src="images/cab.svg" alt="Cab driver" class="scroll-bounce">
+    <p>This short dialogue simulates catching a cab in Bangkok.</p>
+    <div class="dialogue">
+      <p><strong>You:</strong> <span lang="th">ไปสนามบินครับ</span> (pai sa-naam-bin khráp) - To the airport, please.</p>
+      <p><strong>Driver:</strong> <span lang="th">ได้ครับ</span> (dâi khráp) - Sure.</p>
+    </div>
+    <a href="index.html" class="cta-button">Back to Conversations</a>
+  </section>
+
+  <footer>
+    <p>Thai with Tip © 2025</p>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+</html>

--- a/conversations/delivery.html
+++ b/conversations/delivery.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Delivery Conversation</title>
+  <link rel="stylesheet" href="../styles.css">
+  <style>
+    .dialogue p {
+      margin: 10px 0;
+    }
+  </style>
+</head>
+<body>
+  <header class="hero" style="background-image: url('../background.png');">
+    <div class="overlay">
+      <h1>Delivery Guy</h1>
+      <p>Words to use when receiving a package.</p>
+      <a href="index.html" class="cta-button">Back to Conversations</a>
+    </div>
+  </header>
+
+  <section class="section">
+    <img src="images/delivery.svg" alt="Delivery" class="scroll-bounce">
+    <p>Imagine greeting a delivery person at your door.</p>
+    <div class="dialogue">
+      <p><strong>Delivery:</strong> <span lang="th">พัสดุครับ</span> (phát-sà-dù khráp) - Package for you.</p>
+      <p><strong>You:</strong> <span lang="th">ขอบคุณครับ</span> (khòb khun khráp) - Thank you.</p>
+    </div>
+    <a href="index.html" class="cta-button">Back to Conversations</a>
+  </section>
+
+  <footer>
+    <p>Thai with Tip © 2025</p>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+</html>

--- a/conversations/images/cab.svg
+++ b/conversations/images/cab.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 100">
+  <rect x="20" y="40" width="160" height="40" fill="#ffd700" />
+  <rect x="50" y="20" width="40" height="20" fill="#ffd700" />
+  <circle cx="60" cy="90" r="10" fill="#333" />
+  <circle cx="140" cy="90" r="10" fill="#333" />
+</svg>

--- a/conversations/images/delivery.svg
+++ b/conversations/images/delivery.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 100">
+  <rect x="10" y="40" width="100" height="40" fill="#00aaff" />
+  <rect x="110" y="40" width="30" height="20" fill="#00cc66" />
+  <rect x="110" y="60" width="60" height="20" fill="#00aaff" />
+  <circle cx="40" cy="90" r="10" fill="#333" />
+  <circle cx="130" cy="90" r="10" fill="#333" />
+</svg>

--- a/conversations/index.html
+++ b/conversations/index.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Conversation Practice</title>
+  <link rel="stylesheet" href="../styles.css">
+  <style>
+    .scenario-grid {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 20px;
+      justify-content: center;
+    }
+    .scenario-card {
+      background: #fff;
+      border-radius: 12px;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+      width: 200px;
+      padding: 20px;
+      text-align: center;
+      text-decoration: none;
+      color: #333;
+      transition: transform 0.3s;
+    }
+    .scenario-card:hover {
+      transform: scale(1.05);
+    }
+    .scenario-card img {
+      width: 180px;
+      height: 100px;
+      object-fit: contain;
+      margin-bottom: 10px;
+    }
+  </style>
+</head>
+<body>
+  <header class="hero" style="background-image: url('../background.png');">
+    <div class="overlay">
+      <h1>Conversation Practice</h1>
+      <p>Short dialogues for everyday situations.</p>
+      <a href="../index.html" class="cta-button">Back Home</a>
+    </div>
+  </header>
+
+  <section class="section">
+    <h2>Choose a Scenario</h2>
+    <div class="scenario-grid">
+      <a href="cab-driver.html" class="scenario-card">
+        <img src="images/cab.svg" alt="Cab driver">
+        <h3>Cab Driver</h3>
+      </a>
+      <a href="delivery.html" class="scenario-card">
+        <img src="images/delivery.svg" alt="Delivery guy">
+        <h3>Delivery Guy</h3>
+      </a>
+    </div>
+  </section>
+
+  <footer>
+    <p>Thai with Tip © 2025</p>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -63,6 +63,12 @@
     <a href="vocabulary.html" class="cta-button">View Words</a>
   </section>
 
+  <section class="section">
+    <h2>Conversation Practice</h2>
+    <p>Practice short dialogues for real-life situations.</p>
+    <a href="conversations/index.html" class="cta-button">Conversations</a>
+  </section>
+
   <section class="cta-section">
     <h2>Ready to start learning Thai?</h2>
     <a href="Download_page.html" class="cta-button">Download Free Lesson</a>


### PR DESCRIPTION
## Summary
- add new conversations section to the homepage
- create conversation index page with scenario cards
- add cab driver and delivery conversation examples
- include simple SVG images

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6843d90096cc8322b899019bf9439bfd