### PR TITLE
Add gallery images on delivery page

### DIFF
--- a/conversations/delivery.html
+++ b/conversations/delivery.html
@@ -9,6 +9,19 @@
     .dialogue p {
       margin: 10px 0;
     }
+    .image-gallery {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 20px;
+      margin-top: 20px;
+      margin-bottom: 20px;
+    }
+    .delivery-photo {
+      width: 100%;
+      max-width: 1080px;
+      height: auto;
+    }
   </style>
 </head>
 <body>
@@ -30,6 +43,13 @@
       <p><strong>Delivery Guy (handing package):</strong> <span lang="th">พัสดุครับ</span> (phát-sà-dù khráp) - "Package for you."</p>
       <p><strong>You:</strong> <span lang="th">ขอบคุณครับ</span> (khòb khun khráp) - "Thank you."</p>
     </div>
+
+    <div class="image-gallery">
+      <img src="../delivery1.png" alt="Delivery conversation step 1" width="1080" height="1350" class="delivery-photo scroll-bounce">
+      <img src="../delivery2.png" alt="Delivery conversation step 2" width="1080" height="1350" class="delivery-photo scroll-bounce">
+      <img src="../delivery3.png" alt="Delivery conversation step 3" width="1080" height="1350" class="delivery-photo scroll-bounce">
+    </div>
+
     <a href="index.html" class="cta-button">Back to Conversations</a>
   </section>
 


### PR DESCRIPTION
## Summary
- include delivery1, delivery2, and delivery3 images on the Delivery conversation page
- style new gallery to keep images within 1080x1350 px

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6843e504e6f88322b18d8469ad86ff43