### PR TITLE
Remove placeholder delivery image

### DIFF
--- a/conversations/delivery/index.html
+++ b/conversations/delivery/index.html
@@ -34,7 +34,6 @@
   </header>
 
   <section class="section">
-    <img src="../images/delivery.svg" alt="Delivery" class="scroll-bounce">
     <p>Imagine greeting a delivery person at your door.</p>
     <div class="dialogue">
       <p><strong>Delivery Guy (on phone):</strong> <span lang="th">ผมอยู่หน้าบ้านครับ</span> (phǒm yùu nâa bâan khráp) - "I'm in front of your house."</p>

--- a/conversations/images/delivery.svg
+++ b/conversations/images/delivery.svg
@@ -1,7 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 100">
-  <rect x="10" y="40" width="100" height="40" fill="#00aaff" />
-  <rect x="110" y="40" width="30" height="20" fill="#00cc66" />
-  <rect x="110" y="60" width="60" height="20" fill="#00aaff" />
-  <circle cx="40" cy="90" r="10" fill="#333" />
-  <circle cx="130" cy="90" r="10" fill="#333" />
-</svg>


### PR DESCRIPTION
## Summary
- clean up the delivery scenario by deleting the placeholder SVG image
- adjust the conversation HTML to omit the removed image so the page aligns correctly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6843e81cdf608322b3a3ea6ceb217f40