### PR TITLE
Add vocab images

### DIFF
--- a/images/vocab/airport.svg
+++ b/images/vocab/airport.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Airport</text>
+</svg>

--- a/images/vocab/bathroom.svg
+++ b/images/vocab/bathroom.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Bathroom</text>
+</svg>

--- a/images/vocab/beautiful.svg
+++ b/images/vocab/beautiful.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Beautiful</text>
+</svg>

--- a/images/vocab/beer.svg
+++ b/images/vocab/beer.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Beer</text>
+</svg>

--- a/images/vocab/big.svg
+++ b/images/vocab/big.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Big</text>
+</svg>

--- a/images/vocab/brother.svg
+++ b/images/vocab/brother.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Brother</text>
+</svg>

--- a/images/vocab/bus.svg
+++ b/images/vocab/bus.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Bus</text>
+</svg>

--- a/images/vocab/cat.svg
+++ b/images/vocab/cat.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Cat</text>
+</svg>

--- a/images/vocab/cheap.svg
+++ b/images/vocab/cheap.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Cheap</text>
+</svg>

--- a/images/vocab/city.svg
+++ b/images/vocab/city.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>City</text>
+</svg>

--- a/images/vocab/coffee.svg
+++ b/images/vocab/coffee.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Coffee</text>
+</svg>

--- a/images/vocab/cold.svg
+++ b/images/vocab/cold.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Cold</text>
+</svg>

--- a/images/vocab/come.svg
+++ b/images/vocab/come.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Come</text>
+</svg>

--- a/images/vocab/country.svg
+++ b/images/vocab/country.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Country</text>
+</svg>

--- a/images/vocab/daughter.svg
+++ b/images/vocab/daughter.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Daughter</text>
+</svg>

--- a/images/vocab/day.svg
+++ b/images/vocab/day.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Day</text>
+</svg>

--- a/images/vocab/delicious.svg
+++ b/images/vocab/delicious.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Delicious</text>
+</svg>

--- a/images/vocab/dog.svg
+++ b/images/vocab/dog.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Dog</text>
+</svg>

--- a/images/vocab/drink.svg
+++ b/images/vocab/drink.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Drink</text>
+</svg>

--- a/images/vocab/eat.svg
+++ b/images/vocab/eat.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Eat</text>
+</svg>

--- a/images/vocab/excuse_me.svg
+++ b/images/vocab/excuse_me.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Excuse me</text>
+</svg>

--- a/images/vocab/expensive.svg
+++ b/images/vocab/expensive.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Expensive</text>
+</svg>

--- a/images/vocab/family.svg
+++ b/images/vocab/family.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Family</text>
+</svg>

--- a/images/vocab/far.svg
+++ b/images/vocab/far.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Far</text>
+</svg>

--- a/images/vocab/father.svg
+++ b/images/vocab/father.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Father</text>
+</svg>

--- a/images/vocab/food.svg
+++ b/images/vocab/food.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Food</text>
+</svg>

--- a/images/vocab/friend.svg
+++ b/images/vocab/friend.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Friend</text>
+</svg>

--- a/images/vocab/go.svg
+++ b/images/vocab/go.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Go</text>
+</svg>

--- a/images/vocab/good_morning.svg
+++ b/images/vocab/good_morning.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Good morning</text>
+</svg>

--- a/images/vocab/good_night.svg
+++ b/images/vocab/good_night.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Good night</text>
+</svg>

--- a/images/vocab/goodbye.svg
+++ b/images/vocab/goodbye.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Goodbye</text>
+</svg>

--- a/images/vocab/he.svg
+++ b/images/vocab/he.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>He</text>
+</svg>

--- a/images/vocab/help.svg
+++ b/images/vocab/help.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Help</text>
+</svg>

--- a/images/vocab/hot.svg
+++ b/images/vocab/hot.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Hot</text>
+</svg>

--- a/images/vocab/hotel.svg
+++ b/images/vocab/hotel.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Hotel</text>
+</svg>

--- a/images/vocab/how_.svg
+++ b/images/vocab/how_.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>How?</text>
+</svg>

--- a/images/vocab/husband.svg
+++ b/images/vocab/husband.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Husband</text>
+</svg>

--- a/images/vocab/i.svg
+++ b/images/vocab/i.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>I</text>
+</svg>

--- a/images/vocab/know.svg
+++ b/images/vocab/know.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Know</text>
+</svg>

--- a/images/vocab/language.svg
+++ b/images/vocab/language.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Language</text>
+</svg>

--- a/images/vocab/like.svg
+++ b/images/vocab/like.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Like</text>
+</svg>

--- a/images/vocab/listen.svg
+++ b/images/vocab/listen.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Listen</text>
+</svg>

--- a/images/vocab/love.svg
+++ b/images/vocab/love.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Love</text>
+</svg>

--- a/images/vocab/market.svg
+++ b/images/vocab/market.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Market</text>
+</svg>

--- a/images/vocab/money.svg
+++ b/images/vocab/money.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Money</text>
+</svg>

--- a/images/vocab/month.svg
+++ b/images/vocab/month.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Month</text>
+</svg>

--- a/images/vocab/mother.svg
+++ b/images/vocab/mother.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Mother</text>
+</svg>

--- a/images/vocab/near.svg
+++ b/images/vocab/near.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Near</text>
+</svg>

--- a/images/vocab/need.svg
+++ b/images/vocab/need.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Need</text>
+</svg>

--- a/images/vocab/number.svg
+++ b/images/vocab/number.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Number</text>
+</svg>

--- a/images/vocab/open.svg
+++ b/images/vocab/open.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Open</text>
+</svg>

--- a/images/vocab/please.svg
+++ b/images/vocab/please.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Please</text>
+</svg>

--- a/images/vocab/price.svg
+++ b/images/vocab/price.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Price</text>
+</svg>

--- a/images/vocab/read.svg
+++ b/images/vocab/read.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Read</text>
+</svg>

--- a/images/vocab/rice.svg
+++ b/images/vocab/rice.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Rice</text>
+</svg>

--- a/images/vocab/run.svg
+++ b/images/vocab/run.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Run</text>
+</svg>

--- a/images/vocab/school.svg
+++ b/images/vocab/school.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>School</text>
+</svg>

--- a/images/vocab/see_you.svg
+++ b/images/vocab/see_you.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>See you</text>
+</svg>

--- a/images/vocab/she.svg
+++ b/images/vocab/she.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>She</text>
+</svg>

--- a/images/vocab/sister.svg
+++ b/images/vocab/sister.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Sister</text>
+</svg>

--- a/images/vocab/sit.svg
+++ b/images/vocab/sit.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Sit</text>
+</svg>

--- a/images/vocab/sleep.svg
+++ b/images/vocab/sleep.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Sleep</text>
+</svg>

--- a/images/vocab/small.svg
+++ b/images/vocab/small.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Small</text>
+</svg>

--- a/images/vocab/son.svg
+++ b/images/vocab/son.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Son</text>
+</svg>

--- a/images/vocab/sorry.svg
+++ b/images/vocab/sorry.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Sorry</text>
+</svg>

--- a/images/vocab/speak.svg
+++ b/images/vocab/speak.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Speak</text>
+</svg>

--- a/images/vocab/stand.svg
+++ b/images/vocab/stand.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Stand</text>
+</svg>

--- a/images/vocab/stop.svg
+++ b/images/vocab/stop.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Stop</text>
+</svg>

--- a/images/vocab/study.svg
+++ b/images/vocab/study.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Study</text>
+</svg>

--- a/images/vocab/taxi.svg
+++ b/images/vocab/taxi.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Taxi</text>
+</svg>

--- a/images/vocab/tea.svg
+++ b/images/vocab/tea.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Tea</text>
+</svg>

--- a/images/vocab/they.svg
+++ b/images/vocab/they.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>They</text>
+</svg>

--- a/images/vocab/ticket.svg
+++ b/images/vocab/ticket.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Ticket</text>
+</svg>

--- a/images/vocab/time.svg
+++ b/images/vocab/time.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Time</text>
+</svg>

--- a/images/vocab/today.svg
+++ b/images/vocab/today.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Today</text>
+</svg>

--- a/images/vocab/tomorrow.svg
+++ b/images/vocab/tomorrow.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Tomorrow</text>
+</svg>

--- a/images/vocab/train.svg
+++ b/images/vocab/train.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Train</text>
+</svg>

--- a/images/vocab/understand.svg
+++ b/images/vocab/understand.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Understand</text>
+</svg>

--- a/images/vocab/wait.svg
+++ b/images/vocab/wait.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Wait</text>
+</svg>

--- a/images/vocab/walk.svg
+++ b/images/vocab/walk.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Walk</text>
+</svg>

--- a/images/vocab/want.svg
+++ b/images/vocab/want.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Want</text>
+</svg>

--- a/images/vocab/water.svg
+++ b/images/vocab/water.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Water</text>
+</svg>

--- a/images/vocab/we.svg
+++ b/images/vocab/we.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>We</text>
+</svg>

--- a/images/vocab/week.svg
+++ b/images/vocab/week.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Week</text>
+</svg>

--- a/images/vocab/what_.svg
+++ b/images/vocab/what_.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>What?</text>
+</svg>

--- a/images/vocab/when_.svg
+++ b/images/vocab/when_.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>When?</text>
+</svg>

--- a/images/vocab/where_.svg
+++ b/images/vocab/where_.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Where?</text>
+</svg>

--- a/images/vocab/who_.svg
+++ b/images/vocab/who_.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Who?</text>
+</svg>

--- a/images/vocab/why_.svg
+++ b/images/vocab/why_.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Why?</text>
+</svg>

--- a/images/vocab/wife.svg
+++ b/images/vocab/wife.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Wife</text>
+</svg>

--- a/images/vocab/wine.svg
+++ b/images/vocab/wine.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Wine</text>
+</svg>

--- a/images/vocab/work.svg
+++ b/images/vocab/work.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Work</text>
+</svg>

--- a/images/vocab/write.svg
+++ b/images/vocab/write.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Write</text>
+</svg>

--- a/images/vocab/year.svg
+++ b/images/vocab/year.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Year</text>
+</svg>

--- a/images/vocab/yesterday.svg
+++ b/images/vocab/yesterday.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>Yesterday</text>
+</svg>

--- a/images/vocab/you.svg
+++ b/images/vocab/you.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'>
+  <rect width='100%' height='100%' fill='#EFEFEF'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='black'>You</text>
+</svg>

--- a/vocab.js
+++ b/vocab.js
@@ -1,4 +1,3 @@
-const placeholderImage = 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHdpZHRoPScyMDAnIGhlaWdodD0nMjAwJz48cmVjdCB3aWR0aD0nMTAwJScgaGVpZ2h0PScxMDAlJyBmaWxsPScjRkZEMTY2Jy8+PC9zdmc+';
 const vocabulary = [
   {
     thai: 'สวัสดี',
@@ -28,577 +27,577 @@ const vocabulary = [
     thai: 'กรุณา',
     roman: 'karuna',
     english: 'Please',
-    image: placeholderImage
+    image: 'images/vocab/please.svg',
   },
   {
     thai: 'ขอโทษ',
     roman: 'kho thot',
     english: 'Sorry',
-    image: placeholderImage
+    image: 'images/vocab/sorry.svg',
   },
   {
     thai: 'ขอโทษ',
     roman: 'kho thot',
     english: 'Excuse me',
-    image: placeholderImage
+    image: 'images/vocab/excuse_me.svg',
   },
   {
     thai: 'ที่ไหน?',
     roman: 'tee nai?',
     english: 'Where?',
-    image: placeholderImage
+    image: 'images/vocab/where_.svg',
   },
   {
     thai: 'เมื่อไหร่?',
     roman: 'meua rai?',
     english: 'When?',
-    image: placeholderImage
+    image: 'images/vocab/when_.svg',
   },
   {
     thai: 'ใคร?',
     roman: 'krai?',
     english: 'Who?',
-    image: placeholderImage
+    image: 'images/vocab/who_.svg',
   },
   {
     thai: 'อะไร?',
     roman: 'arai?',
     english: 'What?',
-    image: placeholderImage
+    image: 'images/vocab/what_.svg',
   },
   {
     thai: 'ทำไม?',
     roman: 'tammai?',
     english: 'Why?',
-    image: placeholderImage
+    image: 'images/vocab/why_.svg',
   },
   {
     thai: 'ยังไง?',
     roman: 'yang ngai?',
     english: 'How?',
-    image: placeholderImage
+    image: 'images/vocab/how_.svg',
   },
   {
     thai: 'สวัสดีตอนเช้า',
     roman: 'sawatdee ton chao',
     english: 'Good morning',
-    image: placeholderImage
+    image: 'images/vocab/good_morning.svg',
   },
   {
     thai: 'ราตรีสวัสดิ์',
     roman: 'ratri sawat',
     english: 'Good night',
-    image: placeholderImage
+    image: 'images/vocab/good_night.svg',
   },
   {
     thai: 'ลาก่อน',
     roman: 'laa gon',
     english: 'Goodbye',
-    image: placeholderImage
+    image: 'images/vocab/goodbye.svg',
   },
   {
     thai: 'เจอกัน',
     roman: 'jer gan',
     english: 'See you',
-    image: placeholderImage
+    image: 'images/vocab/see_you.svg',
   },
   {
     thai: 'ผม',
     roman: 'phom',
     english: 'I',
-    image: placeholderImage
+    image: 'images/vocab/i.svg',
   },
   {
     thai: 'คุณ',
     roman: 'khun',
     english: 'You',
-    image: placeholderImage
+    image: 'images/vocab/you.svg',
   },
   {
     thai: 'เขา',
     roman: 'khao',
     english: 'He',
-    image: placeholderImage
+    image: 'images/vocab/he.svg',
   },
   {
     thai: 'เธอ',
     roman: 'ter',
     english: 'She',
-    image: placeholderImage
+    image: 'images/vocab/she.svg',
   },
   {
     thai: 'พวกเขา',
     roman: 'phuak khao',
     english: 'They',
-    image: placeholderImage
+    image: 'images/vocab/they.svg',
   },
   {
     thai: 'เรา',
     roman: 'rao',
     english: 'We',
-    image: placeholderImage
+    image: 'images/vocab/we.svg',
   },
   {
     thai: 'เพื่อน',
     roman: 'phuean',
     english: 'Friend',
-    image: placeholderImage
+    image: 'images/vocab/friend.svg',
   },
   {
     thai: 'ครอบครัว',
     roman: 'krob krua',
     english: 'Family',
-    image: placeholderImage
+    image: 'images/vocab/family.svg',
   },
   {
     thai: 'พ่อ',
     roman: 'phaw',
     english: 'Father',
-    image: placeholderImage
+    image: 'images/vocab/father.svg',
   },
   {
     thai: 'แม่',
     roman: 'mae',
     english: 'Mother',
-    image: placeholderImage
+    image: 'images/vocab/mother.svg',
   },
   {
     thai: 'พี่ชาย',
     roman: 'phi chai',
     english: 'Brother',
-    image: placeholderImage
+    image: 'images/vocab/brother.svg',
   },
   {
     thai: 'พี่สาว',
     roman: 'phi sao',
     english: 'Sister',
-    image: placeholderImage
+    image: 'images/vocab/sister.svg',
   },
   {
     thai: 'สามี',
     roman: 'sami',
     english: 'Husband',
-    image: placeholderImage
+    image: 'images/vocab/husband.svg',
   },
   {
     thai: 'ภรรยา',
     roman: 'panraya',
     english: 'Wife',
-    image: placeholderImage
+    image: 'images/vocab/wife.svg',
   },
   {
     thai: 'ลูกชาย',
     roman: 'luk chai',
     english: 'Son',
-    image: placeholderImage
+    image: 'images/vocab/son.svg',
   },
   {
     thai: 'ลูกสาว',
     roman: 'luk sao',
     english: 'Daughter',
-    image: placeholderImage
+    image: 'images/vocab/daughter.svg',
   },
   {
     thai: 'หมา',
     roman: 'maa',
     english: 'Dog',
-    image: placeholderImage
+    image: 'images/vocab/dog.svg',
   },
   {
     thai: 'แมว',
     roman: 'maew',
     english: 'Cat',
-    image: placeholderImage
+    image: 'images/vocab/cat.svg',
   },
   {
     thai: 'น้ำ',
     roman: 'nam',
     english: 'Water',
-    image: placeholderImage
+    image: 'images/vocab/water.svg',
   },
   {
     thai: 'อาหาร',
     roman: 'ahaan',
     english: 'Food',
-    image: placeholderImage
+    image: 'images/vocab/food.svg',
   },
   {
     thai: 'ข้าว',
     roman: 'khao',
     english: 'Rice',
-    image: placeholderImage
+    image: 'images/vocab/rice.svg',
   },
   {
     thai: 'กาแฟ',
     roman: 'kaafae',
     english: 'Coffee',
-    image: placeholderImage
+    image: 'images/vocab/coffee.svg',
   },
   {
     thai: 'ชา',
     roman: 'cha',
     english: 'Tea',
-    image: placeholderImage
+    image: 'images/vocab/tea.svg',
   },
   {
     thai: 'เบียร์',
     roman: 'bia',
     english: 'Beer',
-    image: placeholderImage
+    image: 'images/vocab/beer.svg',
   },
   {
     thai: 'ไวน์',
     roman: 'wain',
     english: 'Wine',
-    image: placeholderImage
+    image: 'images/vocab/wine.svg',
   },
   {
     thai: 'โรงแรม',
     roman: 'rong raem',
     english: 'Hotel',
-    image: placeholderImage
+    image: 'images/vocab/hotel.svg',
   },
   {
     thai: 'แท็กซี่',
     roman: 'taksi',
     english: 'Taxi',
-    image: placeholderImage
+    image: 'images/vocab/taxi.svg',
   },
   {
     thai: 'รถเมล์',
     roman: 'rot mee',
     english: 'Bus',
-    image: placeholderImage
+    image: 'images/vocab/bus.svg',
   },
   {
     thai: 'รถไฟ',
     roman: 'rot fai',
     english: 'Train',
-    image: placeholderImage
+    image: 'images/vocab/train.svg',
   },
   {
     thai: 'สนามบิน',
     roman: 'sanam bin',
     english: 'Airport',
-    image: placeholderImage
+    image: 'images/vocab/airport.svg',
   },
   {
     thai: 'ตลาด',
     roman: 'ta lat',
     english: 'Market',
-    image: placeholderImage
+    image: 'images/vocab/market.svg',
   },
   {
     thai: 'ห้องน้ำ',
     roman: 'hong nam',
     english: 'Bathroom',
-    image: placeholderImage
+    image: 'images/vocab/bathroom.svg',
   },
   {
     thai: 'ช่วยด้วย',
     roman: 'chuay duay',
     english: 'Help',
-    image: placeholderImage
+    image: 'images/vocab/help.svg',
   },
   {
     thai: 'ราคา',
     roman: 'rakha',
     english: 'Price',
-    image: placeholderImage
+    image: 'images/vocab/price.svg',
   },
   {
     thai: 'แพง',
     roman: 'paeng',
     english: 'Expensive',
-    image: placeholderImage
+    image: 'images/vocab/expensive.svg',
   },
   {
     thai: 'ถูก',
     roman: 'thuk',
     english: 'Cheap',
-    image: placeholderImage
+    image: 'images/vocab/cheap.svg',
   },
   {
     thai: 'สวย',
     roman: 'suai',
     english: 'Beautiful',
-    image: placeholderImage
+    image: 'images/vocab/beautiful.svg',
   },
   {
     thai: 'อร่อย',
     roman: 'aroy',
     english: 'Delicious',
-    image: placeholderImage
+    image: 'images/vocab/delicious.svg',
   },
   {
     thai: 'ร้อน',
     roman: 'ron',
     english: 'Hot',
-    image: placeholderImage
+    image: 'images/vocab/hot.svg',
   },
   {
     thai: 'หนาว',
     roman: 'nao',
     english: 'Cold',
-    image: placeholderImage
+    image: 'images/vocab/cold.svg',
   },
   {
     thai: 'ใหญ่',
     roman: 'yai',
     english: 'Big',
-    image: placeholderImage
+    image: 'images/vocab/big.svg',
   },
   {
     thai: 'เล็ก',
     roman: 'lek',
     english: 'Small',
-    image: placeholderImage
+    image: 'images/vocab/small.svg',
   },
   {
     thai: 'ใกล้',
     roman: 'glai',
     english: 'Near',
-    image: placeholderImage
+    image: 'images/vocab/near.svg',
   },
   {
     thai: 'ไกล',
     roman: 'klai',
     english: 'Far',
-    image: placeholderImage
+    image: 'images/vocab/far.svg',
   },
   {
     thai: 'วันนี้',
     roman: 'wan nee',
     english: 'Today',
-    image: placeholderImage
+    image: 'images/vocab/today.svg',
   },
   {
     thai: 'พรุ่งนี้',
     roman: 'phrung nii',
     english: 'Tomorrow',
-    image: placeholderImage
+    image: 'images/vocab/tomorrow.svg',
   },
   {
     thai: 'เมื่อวาน',
     roman: 'muea waan',
     english: 'Yesterday',
-    image: placeholderImage
+    image: 'images/vocab/yesterday.svg',
   },
   {
     thai: 'วัน',
     roman: 'wan',
     english: 'Day',
-    image: placeholderImage
+    image: 'images/vocab/day.svg',
   },
   {
     thai: 'สัปดาห์',
     roman: 'sap daa',
     english: 'Week',
-    image: placeholderImage
+    image: 'images/vocab/week.svg',
   },
   {
     thai: 'เดือน',
     roman: 'duean',
     english: 'Month',
-    image: placeholderImage
+    image: 'images/vocab/month.svg',
   },
   {
     thai: 'ปี',
     roman: 'pii',
     english: 'Year',
-    image: placeholderImage
+    image: 'images/vocab/year.svg',
   },
   {
     thai: 'เวลา',
     roman: 'welaa',
     english: 'Time',
-    image: placeholderImage
+    image: 'images/vocab/time.svg',
   },
   {
     thai: 'เงิน',
     roman: 'ngern',
     english: 'Money',
-    image: placeholderImage
+    image: 'images/vocab/money.svg',
   },
   {
     thai: 'ตั๋ว',
     roman: 'tua',
     english: 'Ticket',
-    image: placeholderImage
+    image: 'images/vocab/ticket.svg',
   },
   {
     thai: 'เลข',
     roman: 'lek',
     english: 'Number',
-    image: placeholderImage
+    image: 'images/vocab/number.svg',
   },
   {
     thai: 'ภาษา',
     roman: 'phasa',
     english: 'Language',
-    image: placeholderImage
+    image: 'images/vocab/language.svg',
   },
   {
     thai: 'โรงเรียน',
     roman: 'rong rian',
     english: 'School',
-    image: placeholderImage
+    image: 'images/vocab/school.svg',
   },
   {
     thai: 'เมือง',
     roman: 'muang',
     english: 'City',
-    image: placeholderImage
+    image: 'images/vocab/city.svg',
   },
   {
     thai: 'ประเทศ',
     roman: 'prathet',
     english: 'Country',
-    image: placeholderImage
+    image: 'images/vocab/country.svg',
   },
   {
     thai: 'รัก',
     roman: 'rak',
     english: 'Love',
-    image: placeholderImage
+    image: 'images/vocab/love.svg',
   },
   {
     thai: 'ชอบ',
     roman: 'chob',
     english: 'Like',
-    image: placeholderImage
+    image: 'images/vocab/like.svg',
   },
   {
     thai: 'อยาก',
     roman: 'yak',
     english: 'Want',
-    image: placeholderImage
+    image: 'images/vocab/want.svg',
   },
   {
     thai: 'ต้องการ',
     roman: 'tongkan',
     english: 'Need',
-    image: placeholderImage
+    image: 'images/vocab/need.svg',
   },
   {
     thai: 'รู้',
     roman: 'roo',
     english: 'Know',
-    image: placeholderImage
+    image: 'images/vocab/know.svg',
   },
   {
     thai: 'เข้าใจ',
     roman: 'kao jai',
     english: 'Understand',
-    image: placeholderImage
+    image: 'images/vocab/understand.svg',
   },
   {
     thai: 'พูด',
     roman: 'phood',
     english: 'Speak',
-    image: placeholderImage
+    image: 'images/vocab/speak.svg',
   },
   {
     thai: 'อ่าน',
     roman: 'aan',
     english: 'Read',
-    image: placeholderImage
+    image: 'images/vocab/read.svg',
   },
   {
     thai: 'เขียน',
     roman: 'khian',
     english: 'Write',
-    image: placeholderImage
+    image: 'images/vocab/write.svg',
   },
   {
     thai: 'ฟัง',
     roman: 'fang',
     english: 'Listen',
-    image: placeholderImage
+    image: 'images/vocab/listen.svg',
   },
   {
     thai: 'กิน',
     roman: 'kin',
     english: 'Eat',
-    image: placeholderImage
+    image: 'images/vocab/eat.svg',
   },
   {
     thai: 'ดื่ม',
     roman: 'deum',
     english: 'Drink',
-    image: placeholderImage
+    image: 'images/vocab/drink.svg',
   },
   {
     thai: 'นอน',
     roman: 'non',
     english: 'Sleep',
-    image: placeholderImage
+    image: 'images/vocab/sleep.svg',
   },
   {
     thai: 'มา',
     roman: 'maa',
     english: 'Come',
-    image: placeholderImage
+    image: 'images/vocab/come.svg',
   },
   {
     thai: 'ไป',
     roman: 'bpai',
     english: 'Go',
-    image: placeholderImage
+    image: 'images/vocab/go.svg',
   },
   {
     thai: 'ทำงาน',
     roman: 'tam ngaan',
     english: 'Work',
-    image: placeholderImage
+    image: 'images/vocab/work.svg',
   },
   {
     thai: 'เรียน',
     roman: 'rian',
     english: 'Study',
-    image: placeholderImage
+    image: 'images/vocab/study.svg',
   },
   {
     thai: 'รอ',
     roman: 'ror',
     english: 'Wait',
-    image: placeholderImage
+    image: 'images/vocab/wait.svg',
   },
   {
     thai: 'เดิน',
     roman: 'dern',
     english: 'Walk',
-    image: placeholderImage
+    image: 'images/vocab/walk.svg',
   },
   {
     thai: 'วิ่ง',
     roman: 'wing',
     english: 'Run',
-    image: placeholderImage
+    image: 'images/vocab/run.svg',
   },
   {
     thai: 'หยุด',
     roman: 'yut',
     english: 'Stop',
-    image: placeholderImage
+    image: 'images/vocab/stop.svg',
   },
   {
     thai: 'นั่ง',
     roman: 'nang',
     english: 'Sit',
-    image: placeholderImage
+    image: 'images/vocab/sit.svg',
   },
   {
     thai: 'ยืน',
     roman: 'yeun',
     english: 'Stand',
-    image: placeholderImage
+    image: 'images/vocab/stand.svg',
   },
   {
     thai: 'เปิด',
     roman: 'bpert',
     english: 'Open',
-    image: placeholderImage
+    image: 'images/vocab/open.svg',
   }
 ];
 


### PR DESCRIPTION
## Summary
- add an `images/vocab` folder containing simple SVGs
- replace all `placeholderImage` references in `vocab.js`

## Testing
- `ls images/vocab | wc -l`

------
https://chatgpt.com/codex/tasks/task_e_684404bddc0883228c0eb70e6f9e1f1f