### PR TITLE
Add random colors to vocabulary cards

### DIFF
--- a/vocab.js
+++ b/vocab.js
@@ -601,11 +601,25 @@ const vocabulary = [
   }
 ];
 
+const cardColors = [
+  '#FFD166', '#06D6A0', '#118AB2', '#EF476F',
+  '#FF9F1C', '#2EC4B6', '#A5668B', '#C30010',
+  '#4D9078', '#FF6B6B', '#48CAE4', '#9D4EDD'
+];
+
+function getRandomColor() {
+  return cardColors[Math.floor(Math.random() * cardColors.length)];
+}
+
 function renderVocabulary() {
   const container = document.getElementById('vocabContainer');
   vocabulary.forEach(item => {
     const card = document.createElement('div');
     card.className = 'vocab-card';
+    if (!item.image.startsWith('data:image')) {
+      card.style.backgroundColor = getRandomColor();
+      card.style.color = '#fff';
+    }
 
     const img = document.createElement('img');
     img.src = item.image;


### PR DESCRIPTION
## Summary
- set up palette of card colors and helper `getRandomColor`
- assign random background colors to vocabulary cards when images have no built-in color

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6844074b1fc08322afabc785764a71e4