### PR TITLE
Refine vocab card layout

### DIFF
--- a/vocab.js
+++ b/vocab.js
@@ -627,24 +627,19 @@ function renderVocabulary() {
     const color = cardColors[idx % cardColors.length];
     header.style.backgroundColor = color;
     header.style.color = getContrast(color);
-    header.textContent = item.english;
-
-    const thai = document.createElement('div');
-    thai.className = 'thai';
-    thai.textContent = item.thai;
-
-    const roman = document.createElement('div');
-    roman.className = 'roman';
-    roman.textContent = item.roman;
+    header.textContent = item.roman;
 
     const english = document.createElement('div');
     english.className = 'english';
     english.textContent = item.english;
 
+    const thai = document.createElement('div');
+    thai.className = 'thai';
+    thai.textContent = item.thai;
+
     card.appendChild(header);
-    card.appendChild(thai);
-    card.appendChild(roman);
     card.appendChild(english);
+    card.appendChild(thai);
     container.appendChild(card);
   });
 }

--- a/vocabulary.html
+++ b/vocabulary.html
@@ -30,21 +30,18 @@
       align-items: center;
       justify-content: center;
       font-size: 2rem;
-      font-weight: bold;
+      font-style: italic;
       color: #fff;
+    }
+    .vocab-card .english {
+      font-weight: bold;
+      margin-bottom: 5px;
+      color: #333;
     }
     .vocab-card .thai {
       font-size: 1.5rem;
       margin: 5px 0;
-    }
-    .vocab-card .roman {
-      font-style: italic;
       color: #555;
-      margin-bottom: 5px;
-    }
-    .vocab-card .english {
-      font-weight: bold;
-      color: #333;
     }
   </style>
 </head>


### PR DESCRIPTION
## Summary
- style updates for vocabulary card layout
- show Romanized text as primary header
- display English and Thai text below

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68440ab098788322b502b36c44a5ae39