### PR TITLE
Add PWA support

### DIFF
--- a/Download_page.html
+++ b/Download_page.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Learn Thai for Free</title>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="manifest" href="manifest.json">
   <style>
     * {
       margin: 0;
@@ -112,6 +113,11 @@
         alert('Submission failed. Please try again.');
       });
     });
+  </script>
+  <script>
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('service-worker.js');
+    }
   </script>
 </body>
 </html>

--- a/conversations/cab-driver.html
+++ b/conversations/cab-driver.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Cab Driver Conversation</title>
   <link rel="stylesheet" href="../styles.css">
+  <link rel="manifest" href="../manifest.json">
   <style>
     .dialogue p {
       margin: 10px 0;
@@ -56,5 +57,10 @@
   </footer>
 
   <script src="../script.js"></script>
+  <script>
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('../service-worker.js');
+    }
+  </script>
 </body>
 </html>

--- a/conversations/delivery/index.html
+++ b/conversations/delivery/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Delivery at the Door</title>
   <link rel="stylesheet" href="../../styles.css">
+  <link rel="manifest" href="../../manifest.json">
   <style>
     .dialogue p {
       margin: 10px 0;
@@ -57,5 +58,10 @@
   </footer>
 
   <script src="../../script.js"></script>
+  <script>
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('../../service-worker.js');
+    }
+  </script>
 </body>
 </html>

--- a/conversations/index.html
+++ b/conversations/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Conversation Practice</title>
   <link rel="stylesheet" href="../styles.css">
+  <link rel="manifest" href="../manifest.json">
   <style>
     .scenario-grid {
       display: flex;
@@ -62,5 +63,10 @@
   </footer>
 
   <script src="../script.js"></script>
+  <script>
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('../service-worker.js');
+    }
+  </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Thai with Tip – Learn Thai for Free</title>
   <link rel="stylesheet" href="styles.css" />
+  <link rel="manifest" href="manifest.json" />
 </head>
 <body>
   <header class="hero" style="background-image: url('background.png');">
@@ -79,5 +80,10 @@
   </footer>
 
   <script src="script.js"></script>
+  <script>
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('service-worker.js');
+    }
+  </script>
 </body>
 </html>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "Thai with Tip",
+  "short_name": "ThaiWithTip",
+  "start_url": "./index.html",
+  "display": "standalone",
+  "theme_color": "#ffffff",
+  "background_color": "#ffffff",
+  "icons": [
+    {
+      "src": "tip.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    },
+    {
+      "src": "cards.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    }
+  ]
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,43 @@
+const CACHE_NAME = 'thai-with-tip-cache-v1';
+const ASSETS = [
+  '/',
+  '/index.html',
+  '/vocabulary.html',
+  '/Download_page.html',
+  '/conversations/index.html',
+  '/conversations/cab-driver.html',
+  '/conversations/delivery/index.html',
+  '/styles.css',
+  '/script.js',
+  '/vocab.js',
+  '/background.png',
+  '/cards.png',
+  '/instagram.png',
+  '/youtube.png',
+  '/tip.png',
+  '/Market.png',
+  '/study.png'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  if (event.request.method !== 'GET' || !event.request.url.startsWith(self.location.origin)) {
+    return;
+  }
+  event.respondWith(
+    caches.match(event.request).then(cached => {
+      if (cached) return cached;
+      return fetch(event.request).then(response => {
+        return caches.open(CACHE_NAME).then(cache => {
+          cache.put(event.request, response.clone());
+          return response;
+        });
+      });
+    })
+  );
+});

--- a/vocabulary.html
+++ b/vocabulary.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Thai Vocabulary</title>
   <link rel="stylesheet" href="styles.css">
+  <link rel="manifest" href="manifest.json">
   <style>
     .vocab-container {
       display: flex;
@@ -63,5 +64,10 @@
   </footer>
 
   <script src="vocab.js"></script>
+  <script>
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('service-worker.js');
+    }
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- create `manifest.json` with app meta and icons
- implement basic `service-worker.js` to cache site assets
- link manifest and register service worker on every HTML page

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685aabfbb684832287ec4a717137c712